### PR TITLE
Fix toggle button initialization order

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -18,11 +18,15 @@ document.addEventListener('DOMContentLoaded', () => {
     chatsList = document.getElementById('chatsList');
     themeToggle = document.getElementById('themeToggle');
 
+    // Initialize theme before setting up event listeners
+    initializeTheme();
+
+    // Setup event listeners after all DOM elements are initialized
     setupEventListeners();
+
     createNewSession();
     loadCourseStats();
     loadChatHistory();
-    initializeTheme();
 });
 
 // Event Listeners


### PR DESCRIPTION
Fixes the theme toggle button not responding to clicks by reordering the initialization sequence in the DOMContentLoaded event handler.

### Changes
- Moved `initializeTheme()` to run before `setupEventListeners()`
- Ensures proper initialization flow for the theme toggle button

Closes #2

---
Generated with [Claude Code](https://claude.ai/code)) | [View Branch](https://github.com/mehdimashayekhi/starting-ragchatbot-codebase/tree/claude/issue-2-20260104-0219